### PR TITLE
Limit suggestions to current locale, and export engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     ".": {
       "import": "./lib/index.js",
       "require": "./lib/index.cjs"
+    },
+    "./engine": {
+      "import": "./lib/client/engine.js",
+      "require": "./lib/client/engine.cjs"
     }
   },
   "types": "./lib/index.d.ts",

--- a/src/client/SearchBox.vue
+++ b/src/client/SearchBox.vue
@@ -77,14 +77,14 @@ export default defineComponent({
     const query = ref("");
     const focused = ref(false);
     const focusIndex = ref(-1);
-    const suggestions = useSuggestions(query);
+    const routeLocale = useRouteLocale();
+    const suggestions = useSuggestions(query, routeLocale.value);
 
     const activeSuggestion = computed(
       () => query.value && focused.value && suggestions.value.length
     );
 
     const router = useRouter();
-    const routeLocale = useRouteLocale();
 
     const locale = computed(() => locales.value[routeLocale.value] ?? {});
 

--- a/src/client/engine.ts
+++ b/src/client/engine.ts
@@ -47,7 +47,7 @@ if (
 }
 
 /** Use suggestions */
-export function useSuggestions(query: Ref<string>): Ref<Suggestion[]> {
+export function useSuggestions(query: Ref<string>, routeLocale: string): Ref<Suggestion[]> {
   const suggestions = ref([] as Suggestion[]);
   let id: NodeJS.Timeout | null = null;
   watch(query, () => {
@@ -68,14 +68,16 @@ export function useSuggestions(query: Ref<string>): Ref<Suggestion[]> {
     const suggestionResults = new Map<string, Suggestion[]>();
     const suggestionSubTitles = new Set<string>();
     for (const page of searchIndex.value) {
-      for (const suggest of extractSuggestions(page, queryStr)) {
-        suggestionSubTitles.add(suggest.parentPageTitle);
-        let list = suggestionResults.get(suggest.parentPageTitle);
-        if (!list) {
-          list = [];
-          suggestionResults.set(suggest.parentPageTitle, list);
+      if(page.pathLocale === routeLocale) { // only extract suggestions for the current locale
+        for (const suggest of extractSuggestions(page, queryStr)) {
+          suggestionSubTitles.add(suggest.parentPageTitle);
+          let list = suggestionResults.get(suggest.parentPageTitle);
+          if (!list) {
+            list = [];
+            suggestionResults.set(suggest.parentPageTitle, list);
+          }
+          list.push(suggest);
         }
-        list.push(suggest);
       }
     }
     const sortedSuggestionSubTitles = [...suggestionSubTitles].sort((a, b) => {


### PR DESCRIPTION
Thank you for developing vuepress-plugin-full-text-search2. I am proposing 2 changes in this pull request:
1. Return suggestions only for the current locale.
2. Export `engine`, which will allow `useSuggestions` to be imported in other components.

An additional suggestion (not in this pull request) is to define a new option:
- `suggestAllLocales` (boolean)
- When `true`, the search engine will return suggestions from all locales.
- When `false`, the search engine will return suggestions only for the current locale.

Thank you for considering this request.